### PR TITLE
fixes

### DIFF
--- a/harvest_exporter/__init__.py
+++ b/harvest_exporter/__init__.py
@@ -5,7 +5,7 @@ import sys
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from fractions import Fraction
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .transferwise import exchange_rate
 
@@ -41,7 +41,9 @@ class Project:
 Aggregated = Dict[str, Dict[str, Project]]
 
 
-def aggregate_time_entries(entries: List[Dict[str, Any]]) -> Aggregated:
+def aggregate_time_entries(
+    entries: List[Dict[str, Any]], hourly_rate: Optional[Fraction]
+) -> Aggregated:
     by_user_and_project: Dict[str, Dict[str, Project]] = defaultdict(
         lambda: defaultdict(lambda: Project())
     )
@@ -62,17 +64,20 @@ def aggregate_time_entries(entries: List[Dict[str, Any]]) -> Aggregated:
             country_code = m.group(1)
 
         project_name = f"{client_name} - {task_name}"
-        rate = entry["task_assignment"]["hourly_rate"]
-        if rate == 0 or rate is None:
-            print(
-                f"WARNING, hourly rate for {client_name}{task_name}/{entry['task']['name']} is 0.0, skip for export",
-                file=sys.stderr,
-            )
-            continue
+        if hourly_rate is not None:
+            rate = hourly_rate
+        else:
+            rate = entry["task_assignment"]["hourly_rate"]
+            if rate == 0 or rate is None:
+                print(
+                    f"WARNING, hourly rate for {client_name}{task_name}/{entry['task']['name']} is 0.0, skip for export",
+                    file=sys.stderr,
+                )
+                continue
 
         project = by_user_and_project[entry["user"]["name"]][project_name]
         # the developer's hourly rate is what we charge to the customer, minus 25%
-        project.hourly_rate = rate * NUMTIDE_RATE
+        project.hourly_rate = rate * Fraction(NUMTIDE_RATE)
         rounded_hours = Fraction(entry["rounded_hours"])
         project.rounded_hours += rounded_hours
         if project.country_code == "":

--- a/harvest_exporter/cli.py
+++ b/harvest_exporter/cli.py
@@ -5,6 +5,7 @@ import calendar
 import os
 import sys
 from datetime import date, datetime, timedelta
+from fractions import Fraction
 
 from harvest import get_time_entries
 
@@ -28,6 +29,11 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("HARVEST_BEARER_TOKEN"),
         required=token is None,
         help="Get one from https://id.getharvest.com/developers (env: HARVEST_BEARER_TOKEN)",
+    )
+    parser.add_argument(
+        "--hourly-rate",
+        type=Fraction,
+        help="Use this hourly rate instead of the one from harvest",
     )
     parser.add_argument(
         "--user",
@@ -107,7 +113,7 @@ def main() -> None:
         args.harvest_account_id, args.harvest_bearer_token, args.start, args.end
     )
 
-    by_user_and_project = aggregate_time_entries(entries)
+    by_user_and_project = aggregate_time_entries(entries, args.hourly_rate)
 
     if args.user:
         for_user = by_user_and_project.get(args.user)

--- a/harvest_exporter/export.py
+++ b/harvest_exporter/export.py
@@ -28,7 +28,7 @@ def as_humanreadable(
             converted_hourly_rate = round_cents(project.converted_hourly_rate(currency))
 
             print(
-                f"  {project_name} ({project.hourly_rate} {project.currency}/h -> {converted_hourly_rate} {currency}/h): {float(project.rounded_hours)}h -> {converted_cost} {currency}"
+                f"  {project_name} ({float(round(project.hourly_rate, 2))} {project.currency}/h -> {converted_hourly_rate} {currency}/h): {float(project.rounded_hours)}h -> {converted_cost} {currency}"
             )
         print("Exchange rates")
         for source_currency, rate in currencies.items():
@@ -46,8 +46,10 @@ def as_csv(
         "rounded_hours",
         "source_cost",
         "source_currency",
+        "source_hourly_rate",
         "target_cost",
         "target_currency",
+        "target_hourly_rate",
         "exchange_rate",
     ]
 

--- a/sevdesk-invoicer/sevdesk_invoicer/__init__.py
+++ b/sevdesk-invoicer/sevdesk_invoicer/__init__.py
@@ -73,8 +73,8 @@ def create_invoice(
                 price=price,
             )
         )
-    start = datetime.strptime(projects[0]["start_date"], "%Y%m%d")
-    end = datetime.strptime(projects[0]["end_date"], "%Y%m%d")
+    start = datetime.strptime(str(projects[0]["start_date"]), "%Y%m%d")
+    end = datetime.strptime(str(projects[0]["end_date"]), "%Y%m%d")
 
     head_text = """
     Terms of payment: Payment within 30 days from receipt of invoice without deductions.


### PR DESCRIPTION
- add flag --hourly-rate to manually override the rate. This prevents crashes when harvest returns null for the rate
- fix crash on csv export because of missing fields source_hourly_rate, target_hourly_rate
- fix int passed to strptime()