### PR TITLE
refactor to allow filtering by client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ harvest-exporter --format json
 harvest-exporter --currency CHF
 ```
 
+* Override hourly rate:
+
+```
+harvest-exporter  --hourly-rate 100
+```
+
+This will override the hourly rate reported by harvest prior to applying the nutmide rate.
+
+* Filter by client:
+
+```
+harvest-exporter --client "Kuutamo"
+```
+
+This can be also used to export hours for clients that are external to numtide (client name starting with "External -")
+
 * Generate an invoice with [sevdesk](https://sevdesk.de)
 
 Generate a bill from the harvest exprt for the customer with the ID 1000
@@ -72,6 +88,7 @@ $ sevdesk-invoicer --customer "1000" harvest.json
 $ working-days-calculator report.csv
 Working days: 171 from 2022-01-12 00:00:00 to 2022-12-29 00:00:00
 ```
+
 
 
 ## API References

--- a/harvest_exporter/export.py
+++ b/harvest_exporter/export.py
@@ -3,7 +3,7 @@ import json
 import sys
 from fractions import Fraction
 
-from . import Aggregated
+from . import User
 
 
 def round_cents(n: Fraction) -> float:
@@ -14,35 +14,45 @@ def round_cents(n: Fraction) -> float:
 
 
 def as_humanreadable(
-    by_user_and_project: Aggregated, start_date: int, end_date: int, currency: str
+    users: dict[str, User],
+    start_date: int,
+    end_date: int,
+    currency: str,
 ) -> None:
     print(f"time: {start_date} -> {end_date}")
-    for user, projects in by_user_and_project.items():
-        print(f"{user}:")
+    for user_name, user in users.items():
+        print(f"{user_name}:")
         currencies = {}
-        for project_name, project in projects.items():
-            if project.currency != currency:
-                currencies[project.currency] = project.exchange_rate(currency)
-            round_cents(project.cost)
-            converted_cost = round_cents(project.converted_cost(currency))
-            converted_hourly_rate = round_cents(project.converted_hourly_rate(currency))
+        for client_name, client in user.clients.items():
+            for task_name, task in client.tasks.items():
+                if task.currency != currency:
+                    currencies[task.currency] = task.exchange_rate(currency)
+                round_cents(task.cost)
+                converted_cost = round_cents(task.converted_cost(currency))
+                converted_hourly_rate = round_cents(
+                    task.converted_hourly_rate(currency)
+                )
 
-            print(
-                f"  {project_name} ({float(round(project.hourly_rate, 2))} {project.currency}/h -> {converted_hourly_rate} {currency}/h): {float(project.rounded_hours)}h -> {converted_cost} {currency}"
-            )
+                print(
+                    f"  {client_name} - {task_name} ({float(round(task.hourly_rate, 2))} {task.currency}/h -> {converted_hourly_rate} {currency}/h): {float(task.rounded_hours)}h -> {converted_cost} {currency}"
+                )
         print("Exchange rates")
         for source_currency, rate in currencies.items():
             print(f"1 {source_currency} -> {float(rate)} {currency}")
 
 
 def as_csv(
-    by_user_and_project: Aggregated, start_date: int, end_date: int, currency: str
+    users: dict[str, User],
+    start_date: int,
+    end_date: int,
+    currency: str,
 ) -> None:
     fieldnames = [
         "user",
         "start_date",
         "end_date",
-        "project",
+        "client",
+        "task",
         "rounded_hours",
         "source_cost",
         "source_currency",
@@ -55,50 +65,57 @@ def as_csv(
 
     writer = csv.DictWriter(sys.stdout, fieldnames=fieldnames)
     writer.writeheader()
-    for user, projects in by_user_and_project.items():
-        for project_name, project in projects.items():
-            writer.writerow(
-                dict(
-                    user=user,
-                    start_date=start_date,
-                    end_date=end_date,
-                    project=project_name,
-                    rounded_hours=float(project.rounded_hours),
-                    source_hourly_rate=round_cents(project.hourly_rate),
-                    source_cost=round_cents(project.cost),
-                    source_currency=project.currency,
-                    target_hourly_rate=round_cents(
-                        project.converted_hourly_rate(currency)
-                    ),
-                    target_cost=round_cents(project.converted_cost(currency)),
-                    target_currency=currency,
-                    exchange_rate=float(project.exchange_rate(currency)),
+    for user_name, user in users.items():
+        for client_name, client in user.clients.items():
+            for task_name, project in client.tasks.items():
+                writer.writerow(
+                    dict(
+                        user=user_name,
+                        start_date=start_date,
+                        end_date=end_date,
+                        client=client_name,
+                        task=task_name,
+                        rounded_hours=float(project.rounded_hours),
+                        source_hourly_rate=round_cents(project.hourly_rate),
+                        source_cost=round_cents(project.cost),
+                        source_currency=project.currency,
+                        target_hourly_rate=round_cents(
+                            project.converted_hourly_rate(currency)
+                        ),
+                        target_cost=round_cents(project.converted_cost(currency)),
+                        target_currency=currency,
+                        exchange_rate=float(project.exchange_rate(currency)),
+                    )
                 )
-            )
 
 
 def as_json(
-    by_user_and_project: Aggregated, start_date: int, end_date: int, currency: str
+    users: dict[str, User],
+    start_date: int,
+    end_date: int,
+    currency: str,
 ) -> None:
     data = []
-    for user, projects in by_user_and_project.items():
-        for project_name, project in projects.items():
-            data.append(
-                dict(
-                    user=user,
-                    start_date=start_date,
-                    end_date=end_date,
-                    project=project_name,
-                    rounded_hours=float(project.rounded_hours),
-                    source_hourly_rate=round_cents(project.hourly_rate),
-                    source_cost=round_cents(project.cost),
-                    source_currency=project.currency,
-                    target_hourly_rate=round_cents(
-                        project.converted_hourly_rate(currency)
-                    ),
-                    target_cost=round_cents(project.converted_cost(currency)),
-                    target_currency=currency,
-                    exchange_rate=float(project.exchange_rate(currency)),
+    for user_name, user in users.items():
+        for client_name, client in user.clients.items():
+            for task_name, project in client.tasks.items():
+                data.append(
+                    dict(
+                        user=user_name,
+                        start_date=start_date,
+                        end_date=end_date,
+                        client=client_name,
+                        task=task_name,
+                        rounded_hours=float(project.rounded_hours),
+                        source_hourly_rate=round_cents(project.hourly_rate),
+                        source_cost=round_cents(project.cost),
+                        source_currency=project.currency,
+                        target_hourly_rate=round_cents(
+                            project.converted_hourly_rate(currency)
+                        ),
+                        target_cost=round_cents(project.converted_cost(currency)),
+                        target_currency=currency,
+                        exchange_rate=float(project.exchange_rate(currency)),
+                    )
                 )
-            )
     json.dump(data, sys.stdout, indent=4, sort_keys=True)


### PR DESCRIPTION
Before we would put client name and task in one project field, now we seperate into client and task.

This changes the csv and json output: The `project` field was dropped in both and instead we have now a `task` and `client` field:

```
$ harvest-exporter --month 06 --year 2023 --user 'Jörg Thalheim' --format csv
user,start_date,end_date,client,task,rounded_hours,source_cost,source_currency,source_hourly_rate,target_cost,target_currency,target_hourly_rate,exchange_rate
Jörg Thalheim,20230601,20230630,Kuutamo,Business Development,2.0,270.0,USD,135.0,246.13,EUR,123.07,0.9116
Jörg Thalheim,20230601,20230630,Kuutamo,Infrastructure Development,7.0,945.0,USD,135.0,861.46,EUR,123.07,0.9116
```

Furthermore clients that start with "External -" gets now a special treatment. Before it would have been visible in the normal export. Now it is hidden by default. One can use the `--client` parameter to export those directly. However note that the actual client name is derived from the project name. i.e. for the "some client" this would look like this:

```
$ harvest-exporter --month 06 --year 2023 --user 'Jörg Thalheim' --client "some client"  --currency USD
time: 20230601 -> 20230630
Jörg Thalheim:
  some client - Business Development (100.0 USD/h -> 100.0 USD/h): 27.5h -> 2750.0 USD
Exchange rates
```

Normal numtide customers can be also filtered like this also internally the client name is derived from the harvest client name:

```
$ harvest-exporter --month 06 --year 2023 --user 'Jörg Thalheim' --client "kuutamo"
time: 20230601 -> 20230630
Jörg Thalheim:
  Kuutamo - Business Development (135.0 USD/h -> 123.07 EUR/h): 2.0h -> 246.13 EUR
  Kuutamo - Infrastructure Development (135.0 USD/h -> 123.07 EUR/h): 7.0h -> 861.46 EUR
Exchange rates
1 USD -> 0.9116 EUR
```