### PR TITLE
fix(sevdesk-api): auto-negate amount for expense vouchers when booking

### DIFF
--- a/sevdesk-api/sevdesk_api/vouchers.py
+++ b/sevdesk-api/sevdesk_api/vouchers.py
@@ -486,6 +486,9 @@ class VoucherOperations:
             voucher_result = self.get_voucher(voucher_id)
             voucher = voucher_result.get("objects", [{}])[0]
             amount = float(voucher.get("sumGross", 0))
+            # Expense vouchers (CREDIT) need negative amounts
+            if voucher.get("creditDebit") == "C":
+                amount = -abs(amount)
 
         # Get transaction to find check account
         trans_result = self.client.get(


### PR DESCRIPTION
## Summary
- When booking a voucher without an explicit amount, the code now checks if the voucher is a CREDIT type (expense/incoming bill) and automatically negates the amount
- Fixes the issue where expense vouchers were showing as "partially paid" instead of "fully paid" when booked against negative transactions

In SevDesk terminology:
- CREDIT (C) = expense voucher (bills we pay) - needs negative amount
- DEBIT (D) = income voucher (invoices we send) - needs positive amount

## Test plan
- [x] Book an expense voucher (CREDIT type) without specifying amount
- [x] Verify voucher status changes to "Paid" (1000) instead of "Partially Paid" (750)