### PR TITLE
kimai-exporter: emit one report per activity

### DIFF
--- a/kimai_exporter/cli.py
+++ b/kimai_exporter/cli.py
@@ -159,67 +159,87 @@ def generate_report(options: ReportOptions) -> None:
         )
         if customer.name != options.client:
             continue
-        total_seconds = Fraction(0)
-        total_rate = Fraction(0)
-        total_internal_rate = Fraction(0)
-        tasks = set()
-        if project.name not in customer.name and customer.name not in project.name:
-            tasks.add(project.name)
+
+        # Group entries by activity so each activity becomes its own
+        # invoice line (different hourly rates and tasks shouldn't be
+        # collapsed into a single line). Within an activity we still sum
+        # across all matching timesheets in the period.
+        per_activity: dict[int, dict[str, Fraction]] = {}
         for entry_data in api.get_time_entries(
             options.start, options.end, user.id, customer.id, project_id=project.id
         ):
             entry = TimeEntry.from_json(entry_data)
-            activity = api.get_activity(entry.activity)
-            tasks.add(activity.name)
-            total_seconds += entry.duration
+            bucket = per_activity.setdefault(
+                entry.activity,
+                {"seconds": Fraction(0), "rate": Fraction(0)},
+            )
+            bucket["seconds"] += entry.duration
+            bucket["rate"] += entry.rate
 
-            total_rate += entry.rate
-            total_internal_rate += entry.internalRate
-
-        if total_seconds == 0:
-            # No matching entries for this user/project in the period.
+        if not per_activity:
             continue
 
-        # Derive the effective hourly rate from the entries we just summed.
-        # Kimai's per-timesheet `rate` already reflects the user/activity/
-        # project-specific rate, and the user endpoint does not expose a
-        # single hourly rate. Previously this called
-        # `api.get_time_entry(user.id)`, which fetches /api/timesheets/{id}
-        # using a *user* id and returned an unrelated timesheet's rate.
-        hourly_rate = total_rate / (Fraction(total_seconds) / 3600)
-
-        # Round hours to 2 decimals (matches Kimai's UI granularity) and
-        # report cost as hours * rate so the downstream invoice line
-        # (`hours @ rate`) reproduces the same total. Log any drift between
-        # the rounded value and the actual sum so it doesn't go unnoticed.
-        rounded_hours = round(Fraction(total_seconds) / 3600, 2)
-        orig_hours = Fraction(total_seconds) / 3600
-        time_err = round(orig_hours - rounded_hours, 4)
-        if time_err < 0:
-            print(f"Time lost: {float(time_err)} hours", file=sys.stderr)
-        elif time_err > 0:
-            print(f"Time gained: {float(time_err)} hours", file=sys.stderr)
-
         exchange_rate = get_exchange_rate(customer.currency, options.currency)
-        target_hourly_rate = hourly_rate * exchange_rate
-        all_reports.append(
-            ProjectReport(
-                agency=options.agency,
-                client=customer.name,
-                end_date=options.end.strftime("%Y%m%d"),
-                exchange_rate=float(exchange_rate),
-                rounded_hours=rounded_hours,
-                source_cost=rounded_hours * hourly_rate,
-                source_currency=customer.currency,
-                source_hourly_rate=hourly_rate,
-                start_date=options.start.strftime("%Y%m%d"),
-                target_cost=rounded_hours * target_hourly_rate,
-                target_currency=options.currency,
-                target_hourly_rate=target_hourly_rate,
-                task=", ".join(tasks),
-                user=user.alias,
+
+        for activity_id, bucket in per_activity.items():
+            total_seconds = bucket["seconds"]
+            total_rate = bucket["rate"]
+            if total_seconds == 0:
+                continue
+            activity = api.get_activity(activity_id)
+
+            # Derive the effective hourly rate from the entries we just
+            # summed. Kimai's per-timesheet `rate` already reflects the
+            # user/activity/project-specific rate; the user endpoint does
+            # not expose a single hourly rate.
+            hourly_rate = total_rate / (Fraction(total_seconds) / 3600)
+
+            # Round hours to 2 decimals (matches Kimai's UI granularity)
+            # and report cost as hours * rate so the downstream invoice
+            # line (`hours @ rate`) reproduces the same total. Log any
+            # drift between the rounded value and the actual sum so it
+            # doesn't go unnoticed.
+            orig_hours = Fraction(total_seconds) / 3600
+            rounded_hours = round(orig_hours, 2)
+            time_err = round(orig_hours - rounded_hours, 4)
+            if time_err < 0:
+                print(
+                    f"{project.name}/{activity.name}: Time lost: {float(time_err)} hours",
+                    file=sys.stderr,
+                )
+            elif time_err > 0:
+                print(
+                    f"{project.name}/{activity.name}: Time gained: {float(time_err)} hours",
+                    file=sys.stderr,
+                )
+
+            target_hourly_rate = hourly_rate * exchange_rate
+            if (
+                project.name in customer.name
+                or customer.name in project.name
+            ):
+                task = activity.name
+            else:
+                task = f"{project.name}: {activity.name}"
+
+            all_reports.append(
+                ProjectReport(
+                    agency=options.agency,
+                    client=customer.name,
+                    end_date=options.end.strftime("%Y%m%d"),
+                    exchange_rate=float(exchange_rate),
+                    rounded_hours=rounded_hours,
+                    source_cost=rounded_hours * hourly_rate,
+                    source_currency=customer.currency,
+                    source_hourly_rate=hourly_rate,
+                    start_date=options.start.strftime("%Y%m%d"),
+                    target_cost=rounded_hours * target_hourly_rate,
+                    target_currency=options.currency,
+                    target_hourly_rate=target_hourly_rate,
+                    task=task,
+                    user=user.alias,
+                )
             )
-        )
 
     print(json.dumps(all_reports, indent=2, cls=JsonEncoder))
 

--- a/kimai_exporter/cli.py
+++ b/kimai_exporter/cli.py
@@ -214,10 +214,7 @@ def generate_report(options: ReportOptions) -> None:
                 )
 
             target_hourly_rate = hourly_rate * exchange_rate
-            if (
-                project.name in customer.name
-                or customer.name in project.name
-            ):
+            if project.name in customer.name or customer.name in project.name:
                 task = activity.name
             else:
                 task = f"{project.name}: {activity.name}"


### PR DESCRIPTION
The exporter previously collapsed every activity under a project into a single `ProjectReport`, joining the activity names into the `task` string. Downstream invoicers (e.g. `sevdesk-invoicer`) therefore ended up with just one invoice line for the whole project, even though different activities often carry different hourly rates and really should be billed as separate items.

Group entries by activity inside each project and emit one `ProjectReport` per `(project, activity)`, with its own summed hours, derived hourly rate, and rounding. Hours are still rounded to 2 decimals; the 'time gained/lost' diagnostic now identifies which project/activity the drift belongs to. Verified against a live Kimai instance: a month containing both Development ($200/h) and Documentation ($140/h) entries now produces two line items totalling the same amount as before.