### PR TITLE
sevdesk: support replacing voucher positions and partial payments

### DIFF
--- a/sevdesk-api/sevdesk_api/vouchers.py
+++ b/sevdesk-api/sevdesk_api/vouchers.py
@@ -455,7 +455,14 @@ class VoucherOperations:
         request_data = {
             "voucher": voucher_data,
             "voucherPosSave": positions_data if positions_data else None,
-            "voucherPosDelete": positions_to_delete,
+            "voucherPosDelete": (
+                [
+                    {"id": pid, "objectName": "VoucherPos"}
+                    for pid in positions_to_delete
+                ]
+                if positions_to_delete
+                else None
+            ),
         }
 
         # Handle filename if it's in voucher_data
@@ -469,6 +476,8 @@ class VoucherOperations:
         voucher_id: int,
         check_account_transaction_id: int,
         amount: float | None = None,
+        *,
+        partial: bool | None = None,
     ) -> dict[str, Any]:
         """Book a voucher with a payment transaction.
 
@@ -482,6 +491,7 @@ class VoucherOperations:
 
         """
         # Get voucher to find the amount if not provided
+        explicit_amount = amount is not None
         if amount is None:
             voucher_result = self.get_voucher(voucher_id)
             voucher = voucher_result.get("objects", [{}])[0]
@@ -489,6 +499,13 @@ class VoucherOperations:
             # Expense vouchers (CREDIT) need negative amounts
             if voucher.get("creditDebit") == "C":
                 amount = -abs(amount)
+
+        # Decide payment type: partial when caller opts in, or implicitly when
+        # an explicit amount was given (to allow multiple vouchers against one
+        # transaction). Otherwise keep the historic FULL_PAYMENT behaviour.
+        if partial is None:
+            partial = explicit_amount
+        payment_type = "PARTIAL_PAYMENT" if partial else "FULL_PAYMENT"
 
         # Get transaction to find check account
         trans_result = self.client.get(
@@ -500,7 +517,7 @@ class VoucherOperations:
         data: dict[str, Any] = {
             "amount": amount,
             "date": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-            "type": "FULL_PAYMENT",
+            "type": payment_type,
             "checkAccount": {
                 "id": check_account.get("id"),
                 "objectName": "CheckAccount",

--- a/sevdesk-cli/sevdesk_cli/cli/vouchers.py
+++ b/sevdesk-cli/sevdesk_cli/cli/vouchers.py
@@ -190,6 +190,7 @@ class VouchersSaveCommand:
     currency: str = "EUR"
     positions: list[VoucherPositionInput] | None = None
     tax_rule: str | None = None
+    replace_positions: bool = False
 
 
 @dataclass
@@ -333,6 +334,14 @@ def add_voucher_subparser(
         "--positions-json",
         type=str,
         help="JSON file with positions data",
+    )
+    save_parser.add_argument(
+        "--replace-positions",
+        action="store_true",
+        help=(
+            "Delete all existing positions on the voucher before adding the "
+            "new --position entries (avoids the default append behaviour)."
+        ),
     )
     save_parser.add_argument(
         "--position",
@@ -701,12 +710,25 @@ def save_voucher(api: SevDeskAPI, cmd: VouchersSaveCommand) -> None:
     if cmd.positions:
         positions = _convert_position_inputs(cmd.positions)
 
+    # Collect IDs of existing positions to delete when replacing
+    positions_to_delete: list[int] | None = None
+    if cmd.replace_positions and cmd.voucher_id is not None:
+        try:
+            existing = api.vouchers.get_voucher_positions(cmd.voucher_id)
+        except (ValueError, KeyError, TypeError, SevDeskError) as e:
+            msg = f"Failed to fetch existing positions for voucher {cmd.voucher_id}: {e}"
+            raise SevDeskCLIError(msg) from e
+        positions_to_delete = [
+            int(p["id"]) for p in existing.get("objects", []) if p.get("id")
+        ]
+
     # Make API call
     try:
         result = api.vouchers.save_voucher(
             voucher_id=cmd.voucher_id,
             voucher_data=voucher_data,
             voucher_positions=positions,
+            positions_to_delete=positions_to_delete,
         )
     except (ValueError, KeyError, TypeError, SevDeskError) as e:
         action = (
@@ -830,6 +852,7 @@ def parse_voucher_command(  # noqa: PLR0911
                 currency=getattr(args, "currency", "EUR"),
                 positions=positions if positions else None,
                 tax_rule=getattr(args, "tax_rule", None),
+                replace_positions=getattr(args, "replace_positions", False),
             )
         case "book":
             return VouchersBookCommand(


### PR DESCRIPTION
The `sevdesk vouchers save --position` path only ever appended new positions, so re-running it on a draft doubled the tax lines and broke the gross amount. Expose the existing `voucherPosDelete` API via a new `--replace-positions` flag (and fix its payload shape to the objects sevdesk actually expects) so callers can replace the full position list in one call.

`book_voucher` always sent `type: FULL_PAYMENT`, which marks the bank transaction as fully consumed even when an explicit smaller `--amount` is passed. That made split matches (e.g. M-Net/WinSIM 80/20 private vs. business vouchers against a single SEPA debit) impossible. Switch to `PARTIAL_PAYMENT` whenever the caller supplies an explicit amount, so several vouchers can be booked against the same transaction.