### PR TITLE
Re-enable mypy for harvest and quipu, fix type errors

### DIFF
--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -8,6 +8,27 @@
   programs.mypy = {
     enable = true;
     directories = {
+      "packages/harvest" = {
+        modules = [
+          "harvest"
+          "harvest_exporter"
+          "harvest_rounder"
+          "kimai"
+          "kimai_exporter"
+          "rest"
+        ];
+      };
+      "packages/quipu-invoicer" = {
+        modules = [
+          "quipu_api"
+          "quipu_invoicer"
+        ];
+        extraPythonPackages = with pkgs.python3.pkgs; [
+          click
+          click-option-group
+          types-requests
+        ];
+      };
       "packages/sevdesk-api" = {
         modules = [ "sevdesk_api" ];
       };

--- a/packages/harvest/kimai/jsonserializer.py
+++ b/packages/harvest/kimai/jsonserializer.py
@@ -23,7 +23,7 @@ class JsonSerializable:
             raise TypeError(msg)
 
         # Get the field names and types of the dataclass
-        cls_fields = {f.name: f.type for f in fields(cls)}  # type: ignore[attr-defined]
+        cls_fields = {f.name: f.type for f in fields(cls)}  # type: ignore[arg-type]
 
         # Filter out any fields in the JSON that are not present in the dataclass
         filtered_data = {}
@@ -46,7 +46,7 @@ class JsonSerializable:
         return cls.from_json(data)
 
     def to_dict(self) -> dict:
-        result = {}
+        result: dict[str, Any] = {}
         for key, value in self.__dict__.items():
             if isinstance(value, Fraction):
                 result[key] = round(float(value), 2)

--- a/packages/quipu-invoicer/quipu_api/__init__.py
+++ b/packages/quipu-invoicer/quipu_api/__init__.py
@@ -182,7 +182,7 @@ class QuipuAPI:
         self, kind: str | None = None, prefix: str | None = None, page: int = 1
     ) -> QuipuResponse:
         endpoint = "accounting_categories"
-        params = {"page[number]": page}
+        params: dict[str, int | str] = {"page[number]": page}
         if kind:
             params["filter[kind]"] = kind
         if prefix:


### PR DESCRIPTION
Stacked on #141 — review only the last commit until that merges.

## Summary

#141 documented that the treefmt mypy entries for the harvest tree and quipu had never actually run (the old `"."` entry generated `./`-prefixed include patterns that never matched, and `quipu-invoicer/` didn't exist as a directory), so they were deleted rather than silently activated. This PR turns that coverage on for real:

- `nix/treefmt.nix`: adds `packages/harvest` (6 modules — the phantom `harvest_report` entry from the old list is not carried over) and `packages/quipu-invoicer` (`quipu_api`, `quipu_invoicer`, with `click`/`click-option-group`/`types-requests` on the mypy PYTHONPATH).
- Fixes the type errors the dead checks were hiding, all annotation-level:
  - `kimai/jsonserializer.py`: the `type: ignore` on `fields(cls)` targeted the wrong error code (`attr-defined` → `arg-type`), and `to_dict`'s result dict was inferred as `dict[str, float]` from its first assignment, rejecting the `isoformat()` branch — now `dict[str, Any]`.
  - `quipu_api/__init__.py`: `params` in `list_accounting_categories` was inferred `dict[str, int]`, rejecting the string filter values — now `dict[str, int | str]`.

No behavior changes; all edits are types/comments.

## Test Plan

- [x] `nix fmt` clean (both new mypy checks run and pass — verified they now actually match files)
- [x] `nix flake check` green