### PR TITLE
Redact secrets from --debug and error output

### DIFF
--- a/packages/kimai/src/kimai_exporter/cli.py
+++ b/packages/kimai/src/kimai_exporter/cli.py
@@ -278,7 +278,10 @@ def main() -> None:
         generate_report(options)
     except Exception:
         print(f"Failed to generate report for {options.client}", file=sys.stderr)
-        print(json.dumps(options, indent=2, cls=JsonEncoder), file=sys.stderr)
+        # Dump the options to aid debugging, but never the API key.
+        redacted = options.to_dict()
+        redacted["kimai_api_key"] = "***"
+        print(json.dumps(redacted, indent=2), file=sys.stderr)
         raise
 
 

--- a/packages/paperless-cli/src/paperless_cli/api.py
+++ b/packages/paperless-cli/src/paperless_cli/api.py
@@ -32,6 +32,22 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+# Keys whose values must never reach the debug log (e.g. mail-account IMAP
+# passwords returned by the API, or an auth token echoed back in a payload).
+_SENSITIVE_KEYS = frozenset({"password", "token", "authorization"})
+
+
+def _redact(obj: Any) -> Any:
+    """Recursively mask sensitive values so debug logging can't leak secrets."""
+    if isinstance(obj, dict):
+        return {
+            k: ("***" if k.lower() in _SENSITIVE_KEYS else _redact(v))
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_redact(v) for v in obj]
+    return obj
+
 
 class PaperlessAPIError(Exception):
     """Exception raised for Paperless API errors."""
@@ -83,7 +99,7 @@ class PaperlessClient:
 
         # Log HTTP request
         logger.debug(f"HTTP Request: {method} {url}")
-        logger.debug(f"Headers: {headers}")
+        logger.debug(f"Headers: {_redact(headers)}")
         if data:
             logger.debug(f"Body: {json.dumps(data, indent=2)}")
 
@@ -99,7 +115,9 @@ class PaperlessClient:
                 response_text = response.read().decode("utf-8")
                 response_body = json.loads(response_text)
                 logger.debug(f"HTTP Response: {response.status}")
-                logger.debug(f"Response body: {json.dumps(response_body, indent=2)}")
+                logger.debug(
+                    f"Response body: {json.dumps(_redact(response_body), indent=2)}"
+                )
                 return cast("dict[str, Any]", response_body)
         except urllib.error.HTTPError as e:
             error_body = e.read().decode("utf-8")

--- a/packages/paperless-cli/src/paperless_cli/cli/main.py
+++ b/packages/paperless-cli/src/paperless_cli/cli/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
@@ -467,8 +467,10 @@ def main() -> None:
     else:
         logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-    # Debug logging
-    logger.debug(f"Options: {options}")
+    # Debug logging — never emit the API token. The "***" here is a redaction
+    # placeholder, not a credential (hence the S106 suppression).
+    safe_options = replace(options, token="***") if options.token else options  # noqa: S106
+    logger.debug(f"Options: {safe_options}")
     logger.debug(f"Command: {options.command}")
 
     if not options.command:

--- a/packages/sevdesk-cli/src/sevdesk_cli/main.py
+++ b/packages/sevdesk-cli/src/sevdesk_cli/main.py
@@ -8,7 +8,7 @@ import logging
 import os
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -328,8 +328,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     options = parse_args(argv)
     configure_logging(debug=options.debug)
 
-    # Debug logging
-    logger.debug("Options: %s", options)
+    # Debug logging — never emit the API token. The "***" here is a redaction
+    # placeholder, not a credential (hence the S106 suppression).
+    safe_options = replace(options, token="***") if options.token else options  # noqa: S106
+    logger.debug("Options: %s", safe_options)
     logger.debug("Command: %s", options.command)
 
     if not options.command:


### PR DESCRIPTION
Three CLIs printed live credentials to stderr/logs:

- `kimai-exporter` dumped the whole `ReportOptions` (including `KIMAI_API_KEY`) to stderr on any report failure.
- `sevdesk-cli` logged the `Options` repr (including the API token) at debug level on every run.
- `paperless-cli` logged the `Options` repr (API token), the request `Authorization` header, and full response bodies at debug level — response bodies for mail accounts include the stored IMAP `password`.

This masks the token in the option dumps, redacts the `Authorization` header, and recursively strips `password`/`token`/`authorization` values from logged response bodies. The `# noqa: S106` on the redaction placeholders is deliberate (the `"***"` is a mask, not a credential).

No behaviour change beyond what is logged. Verified with `nix fmt` (ruff format + check) and a redaction check confirming the token and an IMAP password no longer appear in the output.