### PR TITLE
Don't disable mail rules on partial update

### DIFF
--- a/packages/paperless-cli/src/paperless_cli/cli/main.py
+++ b/packages/paperless-cli/src/paperless_cli/cli/main.py
@@ -231,9 +231,18 @@ def parse_args() -> Options:
     update_parser.add_argument("rule_id", type=int, help="Rule ID")
     update_parser.add_argument("--name", help="New rule name")
     update_parser.add_argument("--order", type=int, help="New rule order")
-    update_parser.add_argument("--enabled", action="store_true", help="Enable rule")
+    # Default to None (not argparse's implicit False) so that omitting both
+    # flags leaves the rule's enabled state untouched on update, instead of
+    # silently disabling it.
     update_parser.add_argument(
-        "--disabled", dest="enabled", action="store_false", help="Disable rule"
+        "--enabled", action="store_true", default=None, help="Enable rule"
+    )
+    update_parser.add_argument(
+        "--disabled",
+        dest="enabled",
+        action="store_false",
+        default=None,
+        help="Disable rule",
     )
     update_parser.add_argument("--account", type=int, help="Mail account ID")
     update_parser.add_argument("--filter-from", help="Filter by sender")


### PR DESCRIPTION
The `mail-rules update` subparser declared `--enabled`/`--disabled` sharing one `dest` with no explicit default, so argparse resolved the dest to `False` whenever neither flag was passed. Any `update` that omitted the flags (e.g. `mail-rules update 3 --name foo`) therefore sent `enabled=False` and silently turned the rule off, stopping its inbox processing.

Default the update flags to `None` so an omitted flag leaves the rule's enabled state untouched; passing `--enabled`/`--disabled` still sets it explicitly. The `create` subparser keeps its `default=True`.

Verified the flag now resolves to `None` (omitted) / `True` (`--enabled`) / `False` (`--disabled`), and `nix fmt` passes.