### PR TITLE
Send ISO dates from harvest-rounder

### DIFF
--- a/packages/harvest/src/harvest_rounder/__init__.py
+++ b/packages/harvest/src/harvest_rounder/__init__.py
@@ -91,8 +91,8 @@ def parse_time_entry(entry: dict[str, Any], increment_minutes: int = 15) -> Time
 def get_time_entries(
     account_id: str,
     access_token: str,
-    from_date: int,
-    to_date: int,
+    from_date: str,
+    to_date: str,
     increment_minutes: int = 15,
 ) -> list[TimeEntry]:
     """Fetch time entries from Harvest and parse them.
@@ -100,8 +100,8 @@ def get_time_entries(
     Args:
         account_id: Harvest account ID
         access_token: Harvest bearer token
-        from_date: Start date as YYYYMMDD integer
-        to_date: End date as YYYYMMDD integer
+        from_date: Start date as a YYYY-MM-DD string
+        to_date: End date as a YYYY-MM-DD string
         increment_minutes: The increment in minutes for rounding
 
     Returns:

--- a/packages/harvest/src/harvest_rounder/cli.py
+++ b/packages/harvest/src/harvest_rounder/cli.py
@@ -47,14 +47,12 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument(
         "--start",
-        type=int,
-        help="Start date i.e. 20220101",
+        help="Start date i.e. 2022-01-01",
     )
 
     parser.add_argument(
         "--end",
-        type=int,
-        help="End date i.e. 20220101",
+        help="End date i.e. 2022-01-01",
     )
 
     parser.add_argument(
@@ -96,11 +94,23 @@ def parse_args() -> argparse.Namespace:
     # Default to the past 4 weeks (28 days) starting from today
     if not args.start and not args.end:
         four_weeks_ago = today - timedelta(days=28)
-        args.start = int(four_weeks_ago.strftime("%Y%m%d"))
-        args.end = int(today.strftime("%Y%m%d"))
+        args.start = four_weeks_ago.strftime("%Y-%m-%d")
+        args.end = today.strftime("%Y-%m-%d")
     elif (args.start and not args.end) or (args.end and not args.start):
         print("Both --start and --end must be provided together", file=sys.stderr)
         sys.exit(1)
+    else:
+        # Validate and normalize caller-supplied dates to YYYY-MM-DD, the
+        # format the Harvest API expects (matching harvest-exporter). This
+        # tool writes back rounded hours, so a malformed bound that widens
+        # the query beyond the intended window must fail rather than fetch.
+        for name in ("start", "end"):
+            value = getattr(args, name)
+            try:
+                parsed = datetime.strptime(value, "%Y-%m-%d")
+            except ValueError:
+                parser.error(f"--{name} must be YYYY-MM-DD, got {value!r}")
+            setattr(args, name, parsed.strftime("%Y-%m-%d"))
 
     return args
 


### PR DESCRIPTION
`harvest-rounder` took `--start`/`--end` as integers and sent them to the Harvest API as `from=20220101&to=20220101`. The API expects `YYYY-MM-DD` (as `harvest-exporter` already sends), so the bare integers are not a valid window. Because the rounder PATCHes rounded hours back onto every entry it fetches, a bound the API ignores could widen the query beyond the intended range and round up historical, already-invoiced entries.

Accept and emit `YYYY-MM-DD` throughout: default the window to `strftime('%Y-%m-%d')`, validate caller-supplied dates and error on a bad format, and type the fetch helper's `from_date`/`to_date` as `str`.

Note: this is a small CLI contract change — `--start 20220101` now errors with a clear message instead of being silently accepted. Verified with `nix fmt` and a check that ISO input normalizes and `20240105`-style input is rejected.