### PR TITLE
harvest-invoicer: i18n, VAT/TLS/validation hardening, and audit fixes

### DIFF
--- a/packages/harvest-invoicer/README.md
+++ b/packages/harvest-invoicer/README.md
@@ -204,7 +204,7 @@ Settings page — fill in your details and they are saved.  Headless
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `tax_id_label` | `"Tax ID"` | Label shown next to your tax ID on the invoice |
+| `tax_id_label` | `"Tax ID"` | Label shown next to your tax ID. A plain string is used verbatim; a per-language map (e.g. `{"en": "Tax ID", "es": "Identificador fiscal"}`) is localized to the invoice language |
 | `date_format` | `"%Y-%m-%d"` | Python strftime pattern for all dates |
 | `legal_note` | _(absent)_ | Legal text at the invoice footer; omitted entirely when not set |
 | `number_template` | _(absent)_ | Invoice number template with `{year}` and `{month}` placeholders |
@@ -251,8 +251,10 @@ invoice; reserved for sending the invoice by email.
 for this client — headings, column labels, payment block, and the PDF page
 footer.  Defaults to the issuer-level `language`, then English.  Dates keep
 following `date_format` and amounts keep one consistent notation regardless
-of language; `tax_id_label` still overrides the translated default.  Custom
-templates receive the same `t(key)` helper and `lang` variable.
+of language.  A plain-string `tax_id_label` still overrides the translated
+default in every language; use the per-language map form (see above) to keep
+the label localized.  Custom templates receive the same `t(key)` helper and
+`lang` variable.
 
 **Optional `extra_lines`**: recurring non-Harvest items (fixed retainer,
 license pass-through, …) automatically appended to every import for that

--- a/packages/harvest-invoicer/src/harvest_invoicer/app.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/app.py
@@ -998,10 +998,14 @@ def create_app(
         # Old client's recurring extras out, new client's in.
         kept = [line for line in inv.lines if line.origin != "extra"]
         inv.lines[:] = kept + client_extra_lines(entry)
-        # The new client's effective VAT applies to all lines (0 when unset,
-        # replacing any rate inherited from the previous client).
+        # The new client's effective VAT applies to Harvest/manual lines (0
+        # when unset, replacing any rate inherited from the previous client).
+        # Extras are skipped — client_extra_lines already gave them the right
+        # rate (their own, or the new client's inherited rate).
         vat = float(str(entry.get("vat_rate") or 0.0))
         for line in inv.lines:
+            if line.origin == "extra":
+                continue
             line.vat_rate = vat
         return _lines_response(inv, _client_inset_oob())
 

--- a/packages/harvest-invoicer/src/harvest_invoicer/app.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/app.py
@@ -35,6 +35,7 @@ from harvest_invoicer.model import (
     Invoice,
     InvoiceLine,
     fmt_money,
+    fmt_rate_pct,
     merge_duplicate_lines,
 )
 from harvest_invoicer.render import _effective_base_url, pdf_from_html, render_html
@@ -149,6 +150,9 @@ def create_app(
         static_folder=str(_STATIC_DIR),
         static_url_path="/static",
     )
+    # Same VAT-rate formatting the invoice PDF uses, so the editor's rate
+    # badge never disagrees with the rendered document (e.g. 7.5% vs "8%").
+    app.jinja_env.filters["rate_pct"] = fmt_rate_pct
 
     invoice = _make_invoice(
         lines,

--- a/packages/harvest-invoicer/src/harvest_invoicer/app.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/app.py
@@ -1377,7 +1377,9 @@ def create_app(
             stripped = row.strip()
             if not stripped:
                 continue
-            parts = [p.strip() for p in stripped.split(";")]
+            # Split from the right so a ';' inside the description survives:
+            # only the trailing price (and optional quantity) are separated.
+            parts = [p.strip() for p in stripped.rsplit(";", 2)]
             if len(parts) not in (2, 3) or not parts[0]:
                 return [], (
                     f"Extra line {lineno}: expected "

--- a/packages/harvest-invoicer/src/harvest_invoicer/app.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/app.py
@@ -153,6 +153,11 @@ def create_app(
     # Same VAT-rate formatting the invoice PDF uses, so the editor's rate
     # badge never disagrees with the rendered document (e.g. 7.5% vs "8%").
     app.jinja_env.filters["rate_pct"] = fmt_rate_pct
+    # Render a stored tax_id_label (plain string or per-language map) back
+    # into its settings text field without flattening a map to its repr.
+    from harvest_invoicer.config import tax_id_label_field  # noqa: PLC0415
+
+    app.jinja_env.filters["tax_id_label_field"] = tax_id_label_field
 
     invoice = _make_invoice(
         lines,
@@ -1344,20 +1349,32 @@ def create_app(
         from harvest_invoicer.config import (  # noqa: PLC0415
             IssuerConfig,
             friendly_error,
+            parse_tax_id_label,
         )
+
+        # tax_id_label may be a plain string or a per-language JSON map.
+        label = parse_tax_id_label(request.form.get("tax_id_label", ""))
 
         # The model is the schema/validation authority (email shape, types).
         try:
-            IssuerConfig.model_validate({**values, "bank": {"iban": iban, "bic": bic}})
+            IssuerConfig.model_validate(
+                {**values, "tax_id_label": label, "bank": {"iban": iban, "bic": bic}}
+            )
         except ValidationError as exc:
             return _status(friendly_error(exc), error=True)
 
         # Mutate the shared issuer dict in place so the preview updates too.
         for f in text_fields:
+            if f == "tax_id_label":
+                continue  # handled below (may be a map, not a plain string)
             if values[f]:
                 issuer[f] = values[f]
             else:
                 issuer.pop(f, None)
+        if label:
+            issuer["tax_id_label"] = label
+        else:
+            issuer.pop("tax_id_label", None)
         bank = issuer.get("bank")
         if not isinstance(bank, dict):
             bank = {}
@@ -1425,6 +1442,7 @@ def create_app(
         from harvest_invoicer.config import (  # noqa: PLC0415
             ClientConfig,
             friendly_error,
+            parse_tax_id_label,
         )
 
         values = {f: request.form.get(f, "").strip() for f in fields}
@@ -1451,6 +1469,9 @@ def create_app(
             model = ClientConfig.model_validate(
                 {
                     **values,
+                    "tax_id_label": parse_tax_id_label(
+                        request.form.get("tax_id_label", "")
+                    ),
                     "vat_rate": request.form.get("vat_rate", "").strip(),
                     "extra_lines": extra_items,
                 }

--- a/packages/harvest-invoicer/src/harvest_invoicer/config.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/config.py
@@ -65,7 +65,7 @@ class IssuerConfig(BaseModel):
     country: str = ""
     phone: str = ""
     tax_id: str = ""
-    tax_id_label: str = ""
+    tax_id_label: str | dict[str, str] = ""
     date_format: str = ""
     number_template: str = ""
     harvest_user: str = ""
@@ -99,7 +99,7 @@ class ClientConfig(BaseModel):
     address_line2: str = ""
     country: str = ""
     tax_id: str = ""
-    tax_id_label: str = ""
+    tax_id_label: str | dict[str, str] = ""
     email: str = ""
     language: str = ""
     vat_rate: float | None = None

--- a/packages/harvest-invoicer/src/harvest_invoicer/config.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/config.py
@@ -11,6 +11,7 @@ environment; it is never serialized to the DB or echoed to the browser.
 
 from __future__ import annotations
 
+from email.utils import parseaddr
 from typing import Literal
 
 from pydantic import (
@@ -35,6 +36,30 @@ DEFAULT_MESSAGE_TEMPLATE = (
 
 Encryption = Literal["starttls", "ssl", "none"]
 DefaultAction = Literal["generate", "send"]
+
+
+def _validate_email_shape(v: str) -> str:
+    """Reject clearly-invalid addresses; an empty string means "unset".
+
+    Only a shape check (local part + a dotted domain), not deliverability —
+    but enough to reject the values the bare ``"@" in v`` test used to let
+    through, e.g. ``"a@"``, ``"@"``, ``"a@@b"``, ``"a@b"``.
+    """
+    if not v:
+        return v
+    _, addr = parseaddr(v)
+    local, _, domain = addr.partition("@")
+    if (
+        not local
+        or not domain
+        or "." not in domain
+        or domain.startswith(".")
+        or domain.endswith(".")
+    ):
+        msg = "Email must be a valid address."
+        raise ValueError(msg)
+    return v
+
 
 # Non-secret SMTP fields overridable from the environment, mapped to their
 # variable names (used for the read-only "set via env" UI indicators).
@@ -77,10 +102,7 @@ class IssuerConfig(BaseModel):
     @field_validator("email")
     @classmethod
     def _email_shape(cls, v: str) -> str:
-        if v and "@" not in v:
-            msg = "Email must be a valid address."
-            raise ValueError(msg)
-        return v
+        return _validate_email_shape(v)
 
 
 class ExtraLine(BaseModel):
@@ -108,10 +130,7 @@ class ClientConfig(BaseModel):
     @field_validator("email")
     @classmethod
     def _email_shape(cls, v: str) -> str:
-        if v and "@" not in v:
-            msg = "Email must be a valid address (missing '@')."
-            raise ValueError(msg)
-        return v
+        return _validate_email_shape(v)
 
     @field_validator("vat_rate", mode="before")
     @classmethod

--- a/packages/harvest-invoicer/src/harvest_invoicer/config.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/config.py
@@ -11,6 +11,7 @@ environment; it is never serialized to the DB or echoed to the browser.
 
 from __future__ import annotations
 
+import json
 from email.utils import parseaddr
 from typing import Literal
 
@@ -59,6 +60,41 @@ def _validate_email_shape(v: str) -> str:
         msg = "Email must be a valid address."
         raise ValueError(msg)
     return v
+
+
+def parse_tax_id_label(raw: str) -> str | dict[str, str]:
+    """Parse the settings-form ``tax_id_label`` field.
+
+    The same text field accepts either a plain label or a per-language
+    JSON map (``{"en": "Tax ID", "es": "Identificador fiscal"}``), so the
+    map survives the settings round-trip instead of being flattened to its
+    ``str`` repr.  Anything that is not a well-formed non-empty object of
+    string→string is kept as the plain trimmed string.
+    """
+    raw = raw.strip()
+    if raw.startswith("{"):
+        try:
+            val = json.loads(raw)
+        except ValueError:
+            return raw
+        if (
+            isinstance(val, dict)
+            and val
+            and all(isinstance(k, str) and isinstance(v, str) for k, v in val.items())
+        ):
+            return dict(val)
+    return raw
+
+
+def tax_id_label_field(v: object) -> str:
+    """Render a stored ``tax_id_label`` back into the settings text field.
+
+    A per-language map is shown as its JSON so it can be edited and saved
+    again; a plain string is shown verbatim.
+    """
+    if isinstance(v, dict):
+        return json.dumps(v, ensure_ascii=False)
+    return str(v) if v else ""
 
 
 # Non-secret SMTP fields overridable from the environment, mapped to their

--- a/packages/harvest-invoicer/src/harvest_invoicer/config.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/config.py
@@ -42,20 +42,22 @@ DefaultAction = Literal["generate", "send"]
 def _validate_email_shape(v: str) -> str:
     """Reject clearly-invalid addresses; an empty string means "unset".
 
-    Only a shape check (local part + a dotted domain), not deliverability —
-    but enough to reject the values the bare ``"@" in v`` test used to let
-    through, e.g. ``"a@"``, ``"@"``, ``"a@@b"``, ``"a@b"``.
+    A structural shape check only (one ``@``, a non-empty local part and a
+    non-empty whitespace-free domain), not deliverability.  It rejects the
+    values the bare ``"@" in v`` test let through (``"a@"``, ``"@"``,
+    ``"a@@b"``) while still accepting single-label internal domains
+    (``"user@localhost"``) for local-relay setups.
     """
     if not v:
         return v
     _, addr = parseaddr(v)
-    local, _, domain = addr.partition("@")
+    local, sep, domain = addr.partition("@")
     if (
-        not local
+        not sep
+        or not local
         or not domain
-        or "." not in domain
-        or domain.startswith(".")
-        or domain.endswith(".")
+        or "@" in domain
+        or any(c.isspace() for c in addr)
     ):
         msg = "Email must be a valid address."
         raise ValueError(msg)
@@ -219,6 +221,13 @@ class SmtpSettings(BaseSettings):
     subject_template: str = DEFAULT_SUBJECT_TEMPLATE
     message_template: str = DEFAULT_MESSAGE_TEMPLATE
     default_action: DefaultAction = "generate"
+
+    @field_validator("from_address", "reply_to")
+    @classmethod
+    def _address_shape(cls, v: str) -> str:
+        # These feed the From:/Reply-To: headers, so hold them to the same
+        # shape check as the issuer/client addresses.
+        return _validate_email_shape(v)
 
     @field_validator("port", mode="before")
     @classmethod

--- a/packages/harvest-invoicer/src/harvest_invoicer/fetch.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/fetch.py
@@ -334,14 +334,19 @@ def resolve_client(
     Otherwise, infer the client name from the first line's concept prefix.
     """
     if client_filter:
-        if client_filter not in clients:
-            available = ", ".join(sorted(clients.keys())) or "(none)"
-            msg = (
-                f"Client '{client_filter}' not found in the configured clients.\n"
-                f"  Available keys: {available}"
-            )
-            raise click.ClickException(msg)
-        return clients[client_filter]
+        if client_filter in clients:
+            return clients[client_filter]
+        # Tolerate case differences on the --client key when it stays
+        # unambiguous (a single case-insensitive match).
+        matches = [k for k in clients if k.casefold() == client_filter.casefold()]
+        if len(matches) == 1:
+            return clients[matches[0]]
+        available = ", ".join(sorted(clients.keys())) or "(none)"
+        msg = (
+            f"Client '{client_filter}' not found in the configured clients.\n"
+            f"  Available keys: {available}"
+        )
+        raise click.ClickException(msg)
 
     # Auto-detect from first line
     if lines:

--- a/packages/harvest-invoicer/src/harvest_invoicer/fetch.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/fetch.py
@@ -175,7 +175,9 @@ def resolve_invoice_number(
         try:
             year, mon = month.split("-")
             return number_template.format(year=year, month=mon)
-        except (ValueError, KeyError):
+        except (ValueError, KeyError, IndexError, AttributeError, TypeError):
+            # Any str.format failure mode (bad spec, unknown/positional field,
+            # attribute access) degrades to the default instead of crashing.
             click.echo(
                 f"  warn: number_template '{number_template}' could not be rendered "
                 f"for month '{month}'; using default.",
@@ -293,12 +295,17 @@ def client_extra_lines(client_entry: dict[str, str]) -> list[InvoiceLine]:
     raw = client_entry.get("extra_lines")
     if not isinstance(raw, list):
         return []
+    # An extra keeps its own ``vat_rate`` when it sets one (e.g. a
+    # reverse-charge disbursement at 0%); otherwise it inherits the client
+    # rate, so a retainer is taxed like the rest of the invoice.
+    client_vat = client_entry.get("vat_rate")
+    inherited_vat = float(client_vat) if client_vat is not None else 0.0
     return [
         InvoiceLine(
             concept=str(item["concept"]),
             unit_price=float(item["unit_price"]),
             quantity=float(item.get("quantity", 1.0)),
-            vat_rate=float(item.get("vat_rate", 0.0)),
+            vat_rate=float(item["vat_rate"]) if "vat_rate" in item else inherited_vat,
             origin="extra",
         )
         for item in raw
@@ -309,9 +316,11 @@ def apply_client_vat(
     lines: list[InvoiceLine],
     client_entry: dict[str, str],
 ) -> list[InvoiceLine]:
-    """Apply the client's optional ``vat_rate`` to every line.
+    """Apply the client's optional ``vat_rate`` to Harvest/manual lines.
 
-    Lines keep their existing rate when the client entry has no
+    Extra lines are skipped — they already carry the correct rate (their
+    own, or the client rate inherited in :func:`client_extra_lines`).  All
+    lines keep their existing rate when the client entry has no
     ``vat_rate``.  Returns the same list for chaining.
     """
     vat_raw = client_entry.get("vat_rate")
@@ -319,6 +328,10 @@ def apply_client_vat(
         return lines
     vat = float(vat_raw)
     for line in lines:
+        # Extras already resolved their VAT in client_extra_lines (own rate
+        # or the inherited client rate); only Harvest/manual lines take it here.
+        if line.origin == "extra":
+            continue
         line.vat_rate = vat
     return lines
 

--- a/packages/harvest-invoicer/src/harvest_invoicer/mail.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/mail.py
@@ -9,6 +9,7 @@ environment only and is never persisted or echoed.
 from __future__ import annotations
 
 import smtplib
+import ssl
 from email.message import EmailMessage
 from typing import TYPE_CHECKING, Any
 
@@ -92,9 +93,13 @@ def _connect(settings: SmtpSettings) -> smtplib.SMTP:
         msg = "SMTP host is not configured — set it in Settings > Email."
         raise MailConfigError(msg)
     port = settings.port or _DEFAULT_PORTS[settings.encryption]
+    # A verifying context (cert chain + hostname): smtplib otherwise defaults
+    # to an *unauthenticated* TLS channel (CERT_NONE), which a MITM can
+    # trivially intercept to harvest the SMTP credentials and the invoice PDF.
+    context = ssl.create_default_context()
     if settings.encryption == "ssl":
         conn: smtplib.SMTP = smtplib.SMTP_SSL(
-            settings.host, port, timeout=_SMTP_TIMEOUT
+            settings.host, port, timeout=_SMTP_TIMEOUT, context=context
         )
     else:
         conn = smtplib.SMTP(settings.host, port, timeout=_SMTP_TIMEOUT)
@@ -102,7 +107,7 @@ def _connect(settings: SmtpSettings) -> smtplib.SMTP:
         # Honor the explicit choice: only upgrade to TLS for "starttls".
         # "none" stays plaintext (for local relays / self-signed dev servers).
         if settings.encryption == "starttls":
-            conn.starttls()
+            conn.starttls(context=context)
             conn.ehlo()
     if settings.username:
         conn.login(settings.username, settings.password.get_secret_value())

--- a/packages/harvest-invoicer/src/harvest_invoicer/mail.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/mail.py
@@ -150,7 +150,10 @@ def send_invoice_email(
         email["Reply-To"] = settings.reply_to
     recipients = [recipient]
     if copy_self and from_address and from_address != recipient:
-        email["Cc"] = from_address
+        # Blind copy: the self-copy is still delivered (it's in ``recipients``
+        # / ``to_addrs``), but ``send_message`` strips the Bcc header from the
+        # transmitted message, so the client never sees the sender's address.
+        email["Bcc"] = from_address
         recipients.append(from_address)
     email["Subject"] = subject.strip() or f"Invoice {invoice.number}"
     email.set_content(message.rstrip() + "\n")

--- a/packages/harvest-invoicer/src/harvest_invoicer/model.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/model.py
@@ -182,3 +182,31 @@ def fmt_vat_cell(line: InvoiceLine) -> str:
     if line.vat_rate == 0:
         return f"{fmt_money(0.0)} (0%)"
     return f"{fmt_money(line.vat)} ({line.vat_rate * 100:.0f}%)"
+
+
+def fmt_tax_label(override: object, lang: str) -> str:
+    """Resolve the tax-ID label for *lang*.
+
+    ``override`` is the issuer/client ``tax_id_label`` field, which may be:
+
+    * a plain string — used verbatim in every language (e.g. a fixed
+      "VAT No."), the historical behaviour; or
+    * a per-language mapping such as ``{"en": "Tax ID", "es":
+      "Identificador fiscal"}`` — the entry for *lang* is used, falling
+      back to the English entry so a label set for one language never
+      leaks into another.
+
+    An absent or empty override falls back to the translated default
+    (``t('tax_id')``), so a client with no override is still localized.
+    """
+    from collections.abc import Mapping  # noqa: PLC0415
+
+    from harvest_invoicer.i18n import translator  # noqa: PLC0415
+
+    if isinstance(override, Mapping):
+        label = override.get(lang) or override.get("en")
+        if label:
+            return str(label)
+    elif isinstance(override, str) and override:
+        return override
+    return translator(lang)("tax_id")

--- a/packages/harvest-invoicer/src/harvest_invoicer/model.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/model.py
@@ -160,12 +160,14 @@ def merge_duplicate_lines(lines: list[InvoiceLine]) -> list[InvoiceLine]:
 
 def fmt_money(n: float) -> str:
     """Format a monetary value as 1,234.56 (English locale, comma thousands, period decimal)."""
-    return f"{n:,.2f}"
+    # ``+ 0.0`` collapses a negative zero (a tiny negative that rounds to
+    # 0.00) so an amount never prints as "-0.00".
+    return f"{round(n, 2) + 0.0:,.2f}"
 
 
 def fmt_qty(n: float) -> str:
     """Format a quantity value (same style as fmt_money)."""
-    return f"{n:,.2f}"
+    return f"{round(n, 2) + 0.0:,.2f}"
 
 
 def fmt_date(d: date, date_format: str = "%Y-%m-%d") -> str:

--- a/packages/harvest-invoicer/src/harvest_invoicer/model.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/model.py
@@ -64,8 +64,14 @@ class InvoiceLine:
 
     @property
     def total(self) -> float:
-        """Line total including VAT."""
-        return self.base + self.vat
+        """Line total including VAT.
+
+        Built from the base and VAT each rounded to cents (not
+        ``round(base + vat)``), so the printed line cells add up exactly:
+        the Total column equals Subtotal + VAT per row, and the sum of the
+        line totals equals the invoice ``grand_total``.
+        """
+        return round(self.base, 2) + round(self.vat, 2)
 
 
 @dataclass

--- a/packages/harvest-invoicer/src/harvest_invoicer/model.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/model.py
@@ -177,11 +177,22 @@ def fmt_date(d: date, date_format: str = "%Y-%m-%d") -> str:
     return d.strftime(date_format)
 
 
+def fmt_rate_pct(rate: float) -> str:
+    """Format a VAT rate as a percentage without spurious trailing zeros.
+
+    Keeps fractional rates honest instead of rounding the label to a whole
+    number: ``0.21`` -> ``"21"``, ``0.075`` -> ``"7.5"``, ``0.001`` ->
+    ``"0.1"``.  (The amount was always exact; only the printed percent was
+    being rounded, which produced legally wrong labels like ``7.50 (8%)``.)
+    """
+    return f"{rate * 100:.2f}".rstrip("0").rstrip(".")
+
+
 def fmt_vat_cell(line: InvoiceLine) -> str:
     """Render the VAT cell: amount and rate percentage."""
     if line.vat_rate == 0:
         return f"{fmt_money(0.0)} (0%)"
-    return f"{fmt_money(line.vat)} ({line.vat_rate * 100:.0f}%)"
+    return f"{fmt_money(line.vat)} ({fmt_rate_pct(line.vat_rate)}%)"
 
 
 def fmt_tax_label(override: object, lang: str) -> str:

--- a/packages/harvest-invoicer/src/harvest_invoicer/render.py
+++ b/packages/harvest-invoicer/src/harvest_invoicer/render.py
@@ -18,6 +18,7 @@ from harvest_invoicer.model import (
     fmt_date,
     fmt_money,
     fmt_qty,
+    fmt_tax_label,
     fmt_vat_cell,
 )
 
@@ -55,6 +56,7 @@ def _build_jinja_env(
     env.filters["qty"] = fmt_qty
     env.filters["fmtdate"] = lambda d: fmt_date(d, date_format)
     env.filters["vat_cell"] = fmt_vat_cell
+    env.filters["tax_label"] = fmt_tax_label
     return env
 
 

--- a/packages/harvest-invoicer/src/harvest_invoicer/templates/invoice.html
+++ b/packages/harvest-invoicer/src/harvest_invoicer/templates/invoice.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang }}">
 
 <head>
   <meta charset="utf-8">
@@ -23,7 +23,7 @@
       <p>{{ issuer.address_line1 }}</p>
       <p>{{ issuer.address_line2 }}</p>
       <p>{{ issuer.country }}</p>
-      <p><span class="muted">{{ issuer.tax_id_label | default(t('tax_id')) }}</span> {{ issuer.tax_id }}</p>
+      <p><span class="muted">{{ issuer.tax_id_label | tax_label(lang) }}</span> {{ issuer.tax_id }}</p>
       <p><span class="muted">{{ t('tel') }}</span> {{ issuer.phone }}</p>
       <p><span class="muted">{{ t('email') }}</span> {{ issuer.email }}</p>
     </div>
@@ -60,7 +60,7 @@
     <p>{{ client.address_line1 }}</p>
     <p>{{ client.address_line2 }}</p>
     <p>{{ client.country }}</p>
-    <p><span class="muted">{{ client.tax_id_label | default(t('tax_id')) }}</span> {{ client.tax_id }}</p>
+    <p><span class="muted">{{ client.tax_id_label | tax_label(lang) }}</span> {{ client.tax_id }}</p>
   </section>
 
   <table class="items">

--- a/packages/harvest-invoicer/src/harvest_invoicer/templates/partials/settings_clients.html
+++ b/packages/harvest-invoicer/src/harvest_invoicer/templates/partials/settings_clients.html
@@ -29,7 +29,7 @@
       </div>
       <div>
         <label class="slabel">Tax ID label</label>
-        <input type="text" name="tax_id_label" value="{{ entry.get('tax_id_label', '') }}">
+        <input type="text" name="tax_id_label" value="{{ entry.get('tax_id_label', '') | tax_id_label_field }}">
         <div class="help">How it's labelled on the invoice</div>
       </div>
       <div>

--- a/packages/harvest-invoicer/src/harvest_invoicer/templates/partials/totals.html
+++ b/packages/harvest-invoicer/src/harvest_invoicer/templates/partials/totals.html
@@ -7,7 +7,7 @@
     <div class="hv-num tb-val">{{ fmt_money(invoice.subtotal) }} <span class="tb-cur">{{ invoice.currency }}</span></div>
   </div>
   <div>
-    <div class="tb-eyebrow">VAT{% if rates | length == 1 %} ({{ (rates[0] * 100) | round | int }}%){% endif %}</div>
+    <div class="tb-eyebrow">VAT{% if rates | length == 1 %} ({{ rates[0] | rate_pct }}%){% endif %}</div>
     <div class="hv-num tb-val">{{ fmt_money(invoice.vat_total) }} <span class="tb-cur">{{ invoice.currency }}</span></div>
   </div>
   <div class="tb-total">

--- a/packages/harvest-invoicer/src/harvest_invoicer/templates/settings.html
+++ b/packages/harvest-invoicer/src/harvest_invoicer/templates/settings.html
@@ -92,7 +92,7 @@
               </div>
               <div>
                 <label class="slabel">Tax ID label</label>
-                <input type="text" name="tax_id_label" value="{{ issuer.get('tax_id_label', '') }}" placeholder="NIF, VAT ID…">
+                <input type="text" name="tax_id_label" value="{{ issuer.get('tax_id_label', '') | tax_id_label_field }}" placeholder="NIF, VAT ID…">
                 <div class="help">How it's labelled on the invoice</div>
               </div>
             </div>

--- a/packages/harvest-invoicer/tests/test_app.py
+++ b/packages/harvest-invoicer/tests/test_app.py
@@ -2056,8 +2056,11 @@ class _FakeSMTP:
 
     sent: list[Any] = []  # noqa: RUF012 — shared capture across instances
 
-    def __init__(self, host: str, port: int, timeout: int = 0) -> None:
+    def __init__(
+        self, host: str, port: int, timeout: int = 0, context: object = None
+    ) -> None:
         self.host, self.port = host, port
+        self.context = context
 
     def __enter__(self) -> Self:
         return self
@@ -2071,8 +2074,8 @@ class _FakeSMTP:
     def has_extn(self, _name: str) -> bool:
         return True
 
-    def starttls(self) -> None:
-        pass
+    def starttls(self, *, context: object = None) -> None:
+        self.context = context
 
     def login(self, _user: str, _password: str) -> None:
         pass
@@ -2200,7 +2203,7 @@ class TestSendInvoice:
         calls: list[str] = []
 
         class Fake(_FakeSMTP):
-            def starttls(self) -> None:
+            def starttls(self, *, context: object = None) -> None:
                 calls.append("starttls")
 
         monkeypatch.setattr(smtplib, "SMTP", Fake)

--- a/packages/harvest-invoicer/tests/test_app.py
+++ b/packages/harvest-invoicer/tests/test_app.py
@@ -978,6 +978,41 @@ class TestExtraLinesInEditor:
             {"concept": "License", "unit_price": 20.0, "quantity": 3.0},
         ]
 
+    def test_settings_saves_extra_line_with_semicolon_in_concept(
+        self, tmp_path: Path
+    ) -> None:
+        clients = {"Acme Corp": _fake_client()}
+        clients_path = tmp_path / "state.db"
+        state_db.save_clients(clients_path, clients)
+        app = create_app(
+            lines=_fake_lines(),
+            issuer=_fake_issuer(),
+            client=clients["Acme Corp"],
+            invoice_number="2026-06",
+            output_path=tmp_path / "invoice.pdf",
+            clients=clients,
+            db_path=clients_path,
+        )
+        app.config["TESTING"] = True
+        form = {
+            "original_key": "Acme Corp",
+            "key": "Acme Corp",
+            "name": "Acme Corp Ltd.",
+            "address_line1": "1 Acme Blvd",
+            "address_line2": "EC1A 1BB London",
+            "country": "United Kingdom",
+            "tax_id": "GB000000000",
+            "extra_lines": "Consulting; phase 1 ; 500 ; 2",
+        }
+        with app.test_client() as c:
+            resp = c.post("/settings/clients/save", data=form)
+            assert b"saved" in resp.data
+        saved = state_db.get_clients(clients_path)
+        # The ';' in the description survives; only price/quantity are split off.
+        assert saved["Acme Corp"]["extra_lines"] == [
+            {"concept": "Consulting; phase 1", "unit_price": 500.0, "quantity": 2.0},
+        ]
+
     def test_settings_rejects_bad_extra_lines(self, tmp_path: Path) -> None:
         app = create_app(
             lines=_fake_lines(),
@@ -2147,7 +2182,9 @@ class TestSendInvoice:
         assert len(_FakeSMTP.sent) == 1
         msg, to_addrs = _FakeSMTP.sent[0]
         assert msg["To"] == "billing@acme.test"
-        assert msg["Cc"] == "me@jane.test"
+        # Self-copy is blind: delivered via to_addrs, not exposed as Cc.
+        assert msg["Bcc"] == "me@jane.test"
+        assert msg["Cc"] is None
         assert to_addrs == ["billing@acme.test", "me@jane.test"]
         att = next(iter(msg.iter_attachments()))
         assert att.get_filename() == "invoice-2026-06.pdf"

--- a/packages/harvest-invoicer/tests/test_app.py
+++ b/packages/harvest-invoicer/tests/test_app.py
@@ -814,6 +814,42 @@ class TestBillToSwitch:
         assert "Retainer" not in concepts  # other client's extras removed
         assert all(line.vat_rate == 0.0 for line in inv.lines)
 
+    def test_switch_preserves_extra_own_vat(self, tmp_path: Path) -> None:
+        # An extra with its own vat_rate (reverse charge) must not be
+        # clobbered by the new client's rate on switch; Harvest lines still
+        # take the client rate.
+        clients = {
+            "Numtide": _fake_client(),
+            "Mixed": {
+                "name": "Mixed S.L.",
+                "address_line1": "X",
+                "address_line2": "Y",
+                "country": "Spain",
+                "tax_id": "B1",
+                "vat_rate": 0.21,
+                "extra_lines": [
+                    {"concept": "Reverse charge", "unit_price": 100.0, "vat_rate": 0.0}
+                ],
+            },
+        }
+        app = create_app(
+            lines=_fake_lines(),
+            issuer=_fake_issuer(),
+            client=clients["Numtide"],
+            invoice_number="2026-06",
+            output_path=tmp_path / "invoice.pdf",
+            clients=clients,
+        )
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            c.post("/invoice/client", data={"client_key": "Mixed"})
+        inv = app.state["invoice"]  # type: ignore[attr-defined]
+        rates = {line.concept: line.vat_rate for line in inv.lines}
+        assert rates["Reverse charge"] == 0.0
+        assert all(
+            line.vat_rate == 0.21 for line in inv.lines if line.origin != "extra"
+        )
+
     def test_unknown_key_is_noop(self, tmp_path: Path) -> None:
         app = self._make_app(tmp_path)
         with app.test_client() as c:

--- a/packages/harvest-invoicer/tests/test_app.py
+++ b/packages/harvest-invoicer/tests/test_app.py
@@ -1013,6 +1013,42 @@ class TestExtraLinesInEditor:
             {"concept": "Consulting; phase 1", "unit_price": 500.0, "quantity": 2.0},
         ]
 
+    def test_settings_saves_tax_id_label_map(self, tmp_path: Path) -> None:
+        # A per-language map typed into the field is stored as a map, not
+        # flattened to its str repr, and round-trips back into the field.
+        clients = {"Acme Corp": _fake_client()}
+        clients_path = tmp_path / "state.db"
+        state_db.save_clients(clients_path, clients)
+        app = create_app(
+            lines=_fake_lines(),
+            issuer=_fake_issuer(),
+            client=clients["Acme Corp"],
+            invoice_number="2026-06",
+            output_path=tmp_path / "invoice.pdf",
+            clients=clients,
+            db_path=clients_path,
+        )
+        app.config["TESTING"] = True
+        form = {
+            "original_key": "Acme Corp",
+            "key": "Acme Corp",
+            "name": "Acme Corp Ltd.",
+            "address_line1": "1 Acme Blvd",
+            "address_line2": "EC1A 1BB London",
+            "country": "United Kingdom",
+            "tax_id": "GB000000000",
+            "tax_id_label": '{"en": "Tax ID", "es": "Identificador fiscal"}',
+        }
+        with app.test_client() as c:
+            resp = c.post("/settings/clients/save", data=form)
+            assert b"saved" in resp.data
+            assert b"Identificador fiscal" in resp.data
+        saved = state_db.get_clients(clients_path)
+        assert saved["Acme Corp"]["tax_id_label"] == {
+            "en": "Tax ID",
+            "es": "Identificador fiscal",
+        }
+
     def test_settings_rejects_bad_extra_lines(self, tmp_path: Path) -> None:
         app = create_app(
             lines=_fake_lines(),

--- a/packages/harvest-invoicer/tests/test_config.py
+++ b/packages/harvest-invoicer/tests/test_config.py
@@ -81,6 +81,15 @@ class TestClientConfig:
             ClientConfig(email="notanemail")
         assert ClientConfig(email="a@b.io").email == "a@b.io"
 
+    @pytest.mark.parametrize("bad", ["a@", "@", "@b.io", "a@@b", "a@b", "a@b."])
+    def test_email_shape_rejects_malformed(self, bad: str) -> None:
+        # The old bare `"@" in v` check let all of these through.
+        with pytest.raises(ValidationError):
+            ClientConfig(email=bad)
+
+    def test_email_empty_is_allowed(self) -> None:
+        assert ClientConfig(email="").email == ""
+
     def test_extra_lines_coerced(self) -> None:
         c = ClientConfig(
             extra_lines=[{"concept": "Fee", "unit_price": "10", "quantity": "2"}]

--- a/packages/harvest-invoicer/tests/test_config.py
+++ b/packages/harvest-invoicer/tests/test_config.py
@@ -8,9 +8,31 @@ from harvest_invoicer.config import (
     IssuerConfig,
     SmtpSettings,
     friendly_error,
+    parse_tax_id_label,
     smtp_env_raw,
 )
 from pydantic import ValidationError
+
+
+class TestParseTaxIdLabel:
+    def test_plain_string_kept(self) -> None:
+        assert parse_tax_id_label("VAT No.") == "VAT No."
+        assert parse_tax_id_label("  NIF  ") == "NIF"
+        assert parse_tax_id_label("") == ""
+
+    def test_json_map_parsed(self) -> None:
+        assert parse_tax_id_label('{"en": "Tax ID", "es": "NIF"}') == {
+            "en": "Tax ID",
+            "es": "NIF",
+        }
+
+    @pytest.mark.parametrize(
+        "raw",
+        ['{"en": 5}', "{}", "{not json", '["en", "es"]', '"just a string"'],
+    )
+    def test_malformed_map_kept_as_string(self, raw: str) -> None:
+        # Anything that is not a non-empty string->string object stays a string.
+        assert parse_tax_id_label(raw) == raw.strip()
 
 
 class TestSmtpSettings:

--- a/packages/harvest-invoicer/tests/test_config.py
+++ b/packages/harvest-invoicer/tests/test_config.py
@@ -67,6 +67,15 @@ class TestSmtpSettings:
         assert s.from_address == "env@from.io"
         assert s.password.get_secret_value() == "secret"
 
+    def test_from_address_shape_validated(self) -> None:
+        with pytest.raises(ValidationError):
+            SmtpSettings(host="h", from_address="a@@b")
+        with pytest.raises(ValidationError):
+            SmtpSettings(host="h", reply_to="nope@")
+        # Empty is fine (unset), and a normal address passes.
+        assert SmtpSettings(host="h").from_address == ""
+        assert SmtpSettings(host="h", from_address="me@x.io").from_address == "me@x.io"
+
     def test_password_excluded_from_dump(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HARVEST_INVOICER_SMTP_PASSWORD", "secret")
         s = SmtpSettings(host="h")
@@ -103,11 +112,18 @@ class TestClientConfig:
             ClientConfig(email="notanemail")
         assert ClientConfig(email="a@b.io").email == "a@b.io"
 
-    @pytest.mark.parametrize("bad", ["a@", "@", "@b.io", "a@@b", "a@b", "a@b."])
+    @pytest.mark.parametrize("bad", ["a@", "@", "@b.io", "a@@b"])
     def test_email_shape_rejects_malformed(self, bad: str) -> None:
         # The old bare `"@" in v` check let all of these through.
         with pytest.raises(ValidationError):
             ClientConfig(email=bad)
+
+    @pytest.mark.parametrize(
+        "ok", ["a@b.io", "user@sub.example.co.uk", "a+b@x.io", "user@localhost"]
+    )
+    def test_email_shape_accepts_valid_including_internal(self, ok: str) -> None:
+        # Single-label internal domains stay valid for local-relay setups.
+        assert ClientConfig(email=ok).email == ok
 
     def test_email_empty_is_allowed(self) -> None:
         assert ClientConfig(email="").email == ""

--- a/packages/harvest-invoicer/tests/test_fetch.py
+++ b/packages/harvest-invoicer/tests/test_fetch.py
@@ -14,9 +14,11 @@ from harvest_exporter.cli import NUMTIDE_RATE
 from harvest_invoicer.fetch import (
     apply_client_vat,
     client_extra_lines,
+    default_invoice_number,
     fetch_lines,
     load_clients,
     resolve_client,
+    resolve_invoice_number,
 )
 from harvest_invoicer.model import InvoiceLine
 
@@ -260,3 +262,55 @@ class TestResolveClient:
     def test_not_found_errors(self) -> None:
         with pytest.raises(click.ClickException, match="not found"):
             resolve_client("nope", {"Acme": {"name": "a"}}, [])
+
+
+class TestExtraLineVat:
+    """Extra lines resolve their VAT once; apply_client_vat never clobbers them."""
+
+    def test_extra_inherits_client_vat_when_unset(self) -> None:
+        entry = {
+            "name": "Acme",
+            "vat_rate": 0.21,
+            "extra_lines": [{"concept": "Retainer", "unit_price": 500.0}],
+        }
+        lines = client_extra_lines(entry)  # type: ignore[arg-type]
+        assert lines[0].vat_rate == pytest.approx(0.21)
+
+    def test_extra_keeps_own_vat_over_client(self) -> None:
+        entry = {
+            "name": "Acme",
+            "vat_rate": 0.21,
+            "extra_lines": [
+                {"concept": "Reverse charge", "unit_price": 500.0, "vat_rate": 0.0}
+            ],
+        }
+        lines = client_extra_lines(entry)  # type: ignore[arg-type]
+        assert lines[0].vat_rate == 0.0
+
+    def test_apply_client_vat_leaves_extras_untouched(self) -> None:
+        harvest = InvoiceLine(concept="Dev", unit_price=100.0, quantity=10.0)
+        extra = InvoiceLine(
+            concept="RC", unit_price=500.0, quantity=1.0, vat_rate=0.0, origin="extra"
+        )
+        apply_client_vat([harvest, extra], {"vat_rate": 0.21})  # type: ignore[arg-type]
+        assert harvest.vat_rate == pytest.approx(0.21)
+        assert extra.vat_rate == 0.0
+
+
+class TestResolveInvoiceNumber:
+    def test_template_renders(self) -> None:
+        assert (
+            resolve_invoice_number("2026-07", number_template="INV-{year}-{month}")
+            == "INV-2026-07"
+        )
+
+    def test_positional_template_falls_back_without_crashing(self) -> None:
+        # A positional {} raises IndexError inside str.format; must degrade.
+        assert resolve_invoice_number(
+            "2026-07", number_template="{}/{month}"
+        ) == default_invoice_number("2026-07")
+
+    def test_unknown_field_falls_back(self) -> None:
+        assert resolve_invoice_number(
+            "2026-07", number_template="{quarter}"
+        ) == default_invoice_number("2026-07")

--- a/packages/harvest-invoicer/tests/test_fetch.py
+++ b/packages/harvest-invoicer/tests/test_fetch.py
@@ -16,6 +16,7 @@ from harvest_invoicer.fetch import (
     client_extra_lines,
     fetch_lines,
     load_clients,
+    resolve_client,
 )
 from harvest_invoicer.model import InvoiceLine
 
@@ -240,3 +241,22 @@ class TestExtraLines:
         p.write_text(json.dumps({"Acme": {"name": "Acme Ltd", "extra_lines": "nope"}}))
         with pytest.raises(click.ClickException, match="must be a list"):
             load_clients(str(p))
+
+
+class TestResolveClient:
+    def test_exact_match(self) -> None:
+        clients = {"Acme Corp": {"name": "Acme"}, "Beta": {"name": "B"}}
+        assert resolve_client("Acme Corp", clients, [])["name"] == "Acme"
+
+    def test_case_insensitive_unique_fallback(self) -> None:
+        clients = {"Acme Corp": {"name": "Acme"}, "Beta": {"name": "B"}}
+        assert resolve_client("acme corp", clients, [])["name"] == "Acme"
+
+    def test_ambiguous_case_match_errors(self) -> None:
+        clients = {"acme": {"name": "a"}, "ACME": {"name": "b"}}
+        with pytest.raises(click.ClickException):
+            resolve_client("Acme", clients, [])
+
+    def test_not_found_errors(self) -> None:
+        with pytest.raises(click.ClickException, match="not found"):
+            resolve_client("nope", {"Acme": {"name": "a"}}, [])

--- a/packages/harvest-invoicer/tests/test_i18n.py
+++ b/packages/harvest-invoicer/tests/test_i18n.py
@@ -10,7 +10,7 @@ from harvest_invoicer.i18n import (
     resolve_language,
     translator,
 )
-from harvest_invoicer.model import Invoice, InvoiceLine
+from harvest_invoicer.model import Invoice, InvoiceLine, fmt_tax_label
 from harvest_invoicer.render import render_html
 
 
@@ -108,3 +108,38 @@ def test_tax_id_label_still_wins_over_translation() -> None:
         _client(language="es", tax_id_label="Identificador fiscal"),
     )
     assert "Identificador fiscal" in html
+
+
+def test_html_lang_attribute_matches_invoice_language() -> None:
+    """The <html lang> attribute follows the resolved invoice language."""
+    es = render_html(_invoice(), _issuer(), _client(language="es"))
+    assert '<html lang="es">' in es
+    en = render_html(_invoice(), _issuer(), _client())
+    assert '<html lang="en">' in en
+
+
+def test_tax_id_label_map_localizes_per_language() -> None:
+    """A per-language tax_id_label map picks the entry for the invoice language."""
+    label_map = {"es": "Identificador fiscal", "en": "Tax reference"}
+    es = render_html(
+        _invoice(), _issuer(), _client(language="es", tax_id_label=label_map)
+    )
+    assert "Identificador fiscal" in es
+    assert "Tax reference" not in es
+    # The Spanish override must NOT leak into an English invoice.
+    en = render_html(_invoice(), _issuer(), _client(tax_id_label=label_map))
+    assert "Tax reference" in en
+    assert "Identificador fiscal" not in en
+
+
+def test_fmt_tax_label_resolution() -> None:
+    # Plain string: verbatim in every language (backwards compatible).
+    assert fmt_tax_label("Steuernummer", "es") == "Steuernummer"
+    # Map: exact language wins, English is the fallback for a missing entry.
+    label_map = {"es": "Identificador fiscal", "en": "Tax reference"}
+    assert fmt_tax_label(label_map, "es") == "Identificador fiscal"
+    assert fmt_tax_label(label_map, "en") == "Tax reference"
+    assert fmt_tax_label(label_map, "fr") == "Tax reference"
+    # Empty / absent override falls back to the translated default.
+    assert fmt_tax_label("", "es") == translator("es")("tax_id")
+    assert fmt_tax_label({}, "es") == translator("es")("tax_id")

--- a/packages/harvest-invoicer/tests/test_mail.py
+++ b/packages/harvest-invoicer/tests/test_mail.py
@@ -1,0 +1,61 @@
+"""Tests for mail.py: SMTP connections must verify the TLS certificate."""
+
+from __future__ import annotations
+
+import smtplib
+import ssl
+
+import pytest
+from harvest_invoicer.config import SMTP_ENV, SmtpSettings
+from harvest_invoicer.mail import _connect
+
+
+@pytest.fixture(autouse=True)
+def _clear_smtp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate SmtpSettings from any ambient HARVEST_INVOICER_SMTP_* vars."""
+    for var in SMTP_ENV.values():
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("HARVEST_INVOICER_SMTP_PASSWORD", raising=False)
+
+
+class _FakeConn:
+    def __init__(self, *_args: object, context: object = None, **_kw: object) -> None:
+        self.init_context = context
+        self.starttls_context: object = "unset"
+
+    def ehlo(self) -> None:
+        pass
+
+    def starttls(self, *, context: object = None) -> None:
+        self.starttls_context = context
+
+    def login(self, *_a: object) -> None:  # pragma: no cover - no creds in tests
+        pass
+
+
+def _assert_verifying(ctx: object) -> None:
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_ssl_connection_verifies_certificate(monkeypatch: pytest.MonkeyPatch) -> None:
+    created: dict[str, _FakeConn] = {}
+
+    def fake_ssl(host: str, port: int, *, timeout: float, context: object) -> _FakeConn:
+        conn = _FakeConn(context=context)
+        created["conn"] = conn
+        return conn
+
+    monkeypatch.setattr(smtplib, "SMTP_SSL", fake_ssl)
+    _connect(SmtpSettings(host="mail.example", encryption="ssl"))
+    _assert_verifying(created["conn"].init_context)
+
+
+def test_starttls_connection_verifies_certificate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = _FakeConn()
+    monkeypatch.setattr(smtplib, "SMTP", lambda *_a, **_k: conn)
+    _connect(SmtpSettings(host="mail.example", encryption="starttls"))
+    _assert_verifying(conn.starttls_context)

--- a/packages/harvest-invoicer/tests/test_model.py
+++ b/packages/harvest-invoicer/tests/test_model.py
@@ -172,3 +172,28 @@ def test_totals_match_displayed_line_amounts() -> None:
     assert per_line == ["1.00", "1.00"]
     assert fmt_money(inv.subtotal) == "2.00"
     assert fmt_money(inv.grand_total) == "2.00"
+
+
+def test_line_total_uses_rounded_components() -> None:
+    """The Total column adds up with the other cells and with the grand total.
+
+    With ``round(base + vat)`` the per-line total diverged from
+    ``round(base) + round(vat)`` and from ``grand_total`` by a cent.
+    """
+    lines = [
+        InvoiceLine(concept=str(i), unit_price=1.005, quantity=1.0, vat_rate=0.10)
+        for i in range(3)
+    ]
+    inv = Invoice(
+        number="X",
+        issue_date=date(2026, 6, 1),
+        due_date=date(2026, 6, 15),
+        lines=lines,
+    )
+    line = lines[0]
+    # Within a row: Subtotal + VAT == Total.
+    assert fmt_money(line.total) == fmt_money(round(line.base, 2) + round(line.vat, 2))
+    assert fmt_money(line.total) == "1.10"
+    # The Total column sums to the printed grand total.
+    assert fmt_money(sum(x.total for x in lines)) == fmt_money(inv.grand_total)
+    assert fmt_money(inv.grand_total) == "3.30"

--- a/packages/harvest-invoicer/tests/test_model.py
+++ b/packages/harvest-invoicer/tests/test_model.py
@@ -83,6 +83,12 @@ def test_fmt_money_zero() -> None:
     assert fmt_money(0.0) == "0.00"
 
 
+def test_fmt_money_negative_zero_normalized() -> None:
+    # A tiny negative that rounds to zero must not print as "-0.00".
+    assert fmt_money(-0.001) == "0.00"
+    assert fmt_money(-0.0) == "0.00"
+
+
 def test_fmt_qty() -> None:
     assert fmt_qty(40.0) == "40.00"
 

--- a/packages/harvest-invoicer/tests/test_model.py
+++ b/packages/harvest-invoicer/tests/test_model.py
@@ -11,6 +11,7 @@ from harvest_invoicer.model import (
     fmt_date,
     fmt_money,
     fmt_qty,
+    fmt_rate_pct,
     fmt_vat_cell,
     merge_duplicate_lines,
 )
@@ -114,6 +115,21 @@ def test_fmt_vat_cell_nonzero() -> None:
     result = fmt_vat_cell(line)
     assert "21%" in result
     assert "21.00" in result
+
+
+def test_fmt_rate_pct_trims_trailing_zeros() -> None:
+    assert fmt_rate_pct(0.21) == "21"
+    assert fmt_rate_pct(0.075) == "7.5"
+    assert fmt_rate_pct(0.001) == "0.1"
+    assert fmt_rate_pct(0.196) == "19.6"
+
+
+def test_fmt_vat_cell_fractional_rate_not_rounded() -> None:
+    # A fractional rate must not be printed as a misleading whole number.
+    line = InvoiceLine(concept="x", unit_price=100.0, quantity=1.0, vat_rate=0.075)
+    result = fmt_vat_cell(line)
+    assert "(7.5%)" in result
+    assert "(8%)" not in result
 
 
 def test_merge_duplicates_preserves_extra_lines() -> None:


### PR DESCRIPTION
An audit of `harvest-invoicer` (plus an adversarial re-review of the fixes themselves) turned up a batch of defects; this PR fixes all of the actionable critical/high/medium/low ones, grouped into commits by theme.

## i18n

- `<html lang="{{ lang }}">` follows the resolved invoice language (was hardcoded `en`).
- `tax_id_label` accepts a per-language map (`{"en": "Tax ID", "es": "…"}`), resolved to the invoice language with English fallback; plain strings unchanged.

## Correctness

- **Invoice totals add up.** Line totals derive from base and VAT each rounded to cents, so Subtotal + VAT equals the Total cell per row and the line totals sum exactly to the grand total (was `round(base + vat)`, off by a cent).
- **Extra-line VAT.** Extras keep their own `vat_rate` when set (e.g. a 0% reverse-charge line) and inherit the client rate otherwise; neither `apply_client_vat` nor the editor's "change client" (`switch_client`) overwrites them any more.
- **VAT-rate label** prints the true rate (`7.5%`, not `8%`) via a shared `fmt_rate_pct` used by both the PDF and the editor badge.
- **`resolve_invoice_number`** degrades to the default on any `str.format` failure (positional `{}`, unknown/attribute fields) instead of crashing.

## Security

- **SMTP TLS is verified.** Both implicit-TLS and STARTTLS pass a verifying `ssl.create_default_context()` (was `CERT_NONE`), closing a MITM window on the SMTP credentials and the invoice PDF.
- **Email validation** requires a structural shape (one `@`, non-empty local, whitespace-free domain) instead of a bare `"@"` check, while still accepting single-label internal domains (`user@localhost`); it now also covers `SmtpSettings.from_address`/`reply_to`.
- Email self-copy uses **Bcc**, not Cc.

## Robustness

- The settings form round-trips a `tax_id_label` map through its text field as JSON, so editing a client/issuer no longer flattens the map to its `str` repr and loses the localized labels.
- `fmt_money`/`fmt_qty` normalise negative zero (no `-0.00`).
- Extra-line parsing splits from the right, so a `;` in the description survives the round-trip.
- `resolve_client` accepts a case-insensitive `--client` key when unambiguous.

## Tests

New `test_mail.py`; extended `test_model.py`, `test_config.py`, `test_i18n.py`, `test_fetch.py`, `test_app.py`. Full suite: **307 passed, 1 skipped**; `ruff`/`mypy` clean; treefmt + package nix checks green.

Findings verified as non-issues and deliberately left unchanged (with reasons): PDF-cache TOCTOU (content-addressed), SQLite `busy_timeout` (5 s by default), `save_clients` replace semantics (needed for delete-last-client), `_connect` str-path mkdir (preserves `:memory:`), `/quit` `os._exit` (standard pattern).

Scope limited to `harvest-invoicer`.